### PR TITLE
fix: jsx column is 1 less

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -4,12 +4,7 @@ export const NodeTypes = <const>{
   ELEMENT: 1,
 };
 
-export const ElementTypes = <const>{
-  ELEMENT: 0,
-  COMPONENT: 1,
-};
-
-export const TagTypes = <number[]>[
-  ElementTypes.ELEMENT,
-  ElementTypes.COMPONENT,
+export const TagTypes = [
+  0, // ELEMENT
+  1, // COMPONENT
 ];

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1,0 +1,34 @@
+import type { Position } from '@vue/compiler-dom';
+import MagicString from 'magic-string';
+import type { Options } from '../types';
+import { TRACE_ID } from './constants';
+import { parse_ID } from './parse_ID';
+import { transform_SFC } from './transform_SFC';
+import { transform_JSX } from './transform_JSX';
+
+export function transform(
+  code: string,
+  id: string,
+  options: Required<Options>,
+) {
+  const { root, sourceMap } = options;
+
+  const s = new MagicString(code);
+
+  const parsed = parse_ID(id, root);
+  if (parsed.isSfc) {
+    transform_SFC(code, replace);
+  } else if (parsed.isJsx) {
+    transform_JSX(code, replace, parsed);
+  }
+
+  function replace(pos: Position) {
+    const { offset, line, column } = pos;
+    s.prependLeft(offset, ` ${TRACE_ID}="${parsed.file}:${line}:${column}"`);
+  }
+
+  return {
+    code: s.toString(),
+    map: sourceMap ? s.generateMap() : null,
+  };
+}

--- a/src/core/transform_SFC.ts
+++ b/src/core/transform_SFC.ts
@@ -9,10 +9,7 @@ import { parse, transform } from '@vue/compiler-dom';
 import { NodeTypes, TagTypes } from './constants';
 import { transform_JSX } from './transform_JSX';
 
-export function transform_SFC(
-  code: string,
-  transformer: (pos: Position) => void,
-) {
+export function transform_SFC(code: string, cb: (pos: Position) => void) {
   const ast = parse(code);
   transform(ast, {
     nodeTransforms: [
@@ -22,10 +19,10 @@ export function transform_SFC(
           TagTypes.includes(node.tagType)
         ) {
           const { start } = node.loc;
-
-          transformer({
+          const offset = start.offset + node.tag.length + 1;
+          cb({
             ...start,
-            offset: start.offset + node.tag.length + 1,
+            offset,
           });
         }
       },
@@ -34,7 +31,7 @@ export function transform_SFC(
 
   const jsxOpts = resolveJsxOptions(ast);
   if (jsxOpts) {
-    transform_JSX(jsxOpts.code, transformer, jsxOpts);
+    transform_JSX(jsxOpts.code, cb, jsxOpts);
   }
 }
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,10 +9,10 @@ export const tsup: Options = {
   shims: false,
   cjsInterop: true,
   external: [
-    '@vue/compiler-dom',
     '@babel/core',
     '@babel/parser',
     '@babel/plugin-syntax-jsx',
     '@babel/plugin-syntax-typescript',
+    '@vue/compiler-dom',
   ],
 };


### PR DESCRIPTION
Let's say you have a component like this

```html
<!-- src/App.vue -->
<script lang="tsx">
  import { defineComponent } from 'vue';

  export default defineComponent({
    setup() {
      return <div>hello word</div>;
    },
  });
</script>
```

Now it compiles

```html
<!-- src/App.vue -->
<script lang="tsx">
  import { defineComponent } from 'vue';

  export default defineComponent({
    setup() {
      return <div __source="/src/App.vue:7:13">hello word</div>;
    },
  });
</script>
```

Should be compiled to

```html
<!-- src/App.vue -->
<script lang="tsx">
  import { defineComponent } from 'vue';

  export default defineComponent({
    setup() {
      return <div __source="/src/App.vue:7:14">hello word</div>;
    },
  });
</script>
```
