### PR TITLE
fix: `process.env.NODE_ENV` is undefined

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,11 +2,12 @@ import { type UnpluginFactory, createUnplugin } from 'unplugin';
 import { createFilter } from '@rollup/pluginutils';
 import { type ResolvedOptions, type Options } from '../types';
 import { TRACE_ID } from './constants';
+import { isDev } from './isDev';
 import { parse_ID } from './parse_ID';
 import { transform } from './transform';
 
 export const unpluginFactory: UnpluginFactory<Options> = (options = {}) => {
-  if (process.env.NODE_ENV !== 'development') {
+  if (!isDev()) {
     return {
       name: 'unplugin-vue-source',
     };

--- a/src/core/isDev.ts
+++ b/src/core/isDev.ts
@@ -1,0 +1,3 @@
+export function isDev() {
+  return !(process.env.NODE_ENV && process.env.NODE_ENV !== 'development');
+}

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -1,7 +1,8 @@
 import { TRACE_ID } from './core/constants';
+import { isDev } from './core/isDev';
 export default {
   install(app: any) {
-    if (process.env.NODE_ENV === 'development') {
+    if (isDev()) {
       app.mixin({
         props: {
           [TRACE_ID]: String,


### PR DESCRIPTION
Handle the case where `process.env.NODE_ENV` is undefined.